### PR TITLE
redmine_interface_test.py: begin using module 'unittest'

### DIFF
--- a/redmine_interface_test.py
+++ b/redmine_interface_test.py
@@ -1,35 +1,87 @@
 #!/usr/bin/python
 
-try:
-    import redmine_interface
-except ImportError as ie:
-    print ie
-    exit(1)
+import argparse
+import redmine_interface
+import unittest
 
-redmineurl = "http://www.redmine.org"
-testtrackers = ["Defect|bugs","Feature|features","Patch|patches"]
-redmine_interface.setup(redmineurl, testtrackers)
+redmine_url = "http://www.redmine.org"
+testtrackers = ["Defect|bugs", "Feature|features", "Patch|patches"]
+
+DEFAULT_VERBOSITY_LEVEL = 0
 
 
-def perform_command_test(cmd):
-    res = redmine_interface.parse_command(cmd)
-    print "".join(res)
+class TestRedmineIfFunctions(unittest.TestCase):
+    def setUp(self):
+        global redmine_url
 
-perform_command_test("")
-perform_command_test([])
-perform_command_test("17113")
-perform_command_test(["17113"])
-perform_command_test(["help"])
+        redmine_interface.setup(redmine_url, testtrackers)
 
-print "FETCH BUGS"
-res = redmine_interface.parse_command(["bugs"])
-for r in res:
-    print r
-print "FETCH FEATURES"
-res = redmine_interface.parse_command(["features"])
-for r in res:
-    print r
+    def test_help(self):
+        res = redmine_interface.parse_command(["help"])
+        self.assertRegexpMatches("".join(res), "Available commands:")
 
-res = redmine_interface.parse_command(["listp"])
-for r in res:
-    print r
+    def test_empty_string(self):
+        res = redmine_interface.parse_command("")
+        self.assertRegexpMatches("".join(res), "Available commands:")
+
+    def test_empty_list(self):
+        res = redmine_interface.parse_command([])
+        self.assertRegexpMatches("".join(res), "Available commands:")
+
+    def test_single_issue_not_list_formatted(self):
+        res = redmine_interface.parse_command("17113")
+        self.assertIn("'cmd' must be a list of strings", "".join(res))
+
+    def test_single_issue_list_formatted(self):
+        res = redmine_interface.parse_command(["17113"])
+        self.assertEqual("".join(res), "Parent task invalid although type ahead shows ticket @ http://www.redmine.org/issues/17113")
+
+    def test_listp(self):
+        res = redmine_interface.parse_command(["listp"])
+        for r in res:
+            self.assertEqual(r, "Redmine")
+
+
+def _main():
+
+    global DEFAULT_VERBOSITY_LEVEL
+    global redmine_url
+
+    verbosity_level = DEFAULT_VERBOSITY_LEVEL
+
+    argparser = argparse.ArgumentParser()
+    argparser.add_argument('-u', '--url', help='Specify a redmine URL \
+                           (do not forget http(s):// !)')
+    argparser.add_argument('-v', '--verbosity', help='Specify verbosity for \
+                           printouts during test execution. \
+                           Valid values = 0,1,2,3. Default value = 0')
+    args = argparser.parse_args()
+
+    if args.verbosity:
+        verbosity_level = int(args.verbosity)
+    if args.url:
+        redmine_url = args.url
+
+    print("Verbosity level = %d" % verbosity_level)
+    print("Redmine URL = %s" % redmine_url)
+
+    suite = unittest.TestLoader().loadTestsFromTestCase(TestRedmineIfFunctions)
+    print "###################"
+    unittest.TextTestRunner(verbosity=verbosity_level).run(suite)
+
+    print "###################"
+    print " Tests yet to be made into unit test cases"
+    print "###################"
+
+#    print "FETCH BUGS"
+#    res = redmine_interface.parse_command(["bugs"])
+#    for r in res:
+#        print r
+
+#    print "FETCH FEATURES"
+#    res = redmine_interface.parse_command(["features"])
+#    for r in res:
+#        print r
+
+if __name__ == '__main__':
+    _main()


### PR DESCRIPTION
Use the module 'unittest' to specify tests
and make test result interpretation easier.

Change-Id: I9d893b5de2165fabb765cafbd35b5ab05c45e525
Signed-off-by: Magnus Karlsson <magnus@technux.se>
Signed-off-by: Petter Mabäcker <petter@technux.se>