### PR TITLE
ircbot.py: more graceful printout when connection to server fails

### DIFF
--- a/ircbot.py
+++ b/ircbot.py
@@ -202,8 +202,11 @@ def _main():
 
     except KeyboardInterrupt:
         print "\n\n'Ctrl + C' detected"
-        leave_irc_network()
-        print "Exiting"
+    except socket.gairerror as (err, msg):
+        print msg
+
+    leave_irc_network()
+    print "Exiting"
 
 if __name__ == "__main__":
     _main()


### PR DESCRIPTION
Can this be merged without the creation of a merge commit?

Print something "nicer" than a stack trace when
connection to IRC server fails, for example because
of absence of Internet access.

Signed-off-by: Magnus Karlsson magnus@technux.se
